### PR TITLE
fix(embeds): Update Instagram embed domain

### DIFF
--- a/internal/instaray/instaray.go
+++ b/internal/instaray/instaray.go
@@ -38,7 +38,7 @@ func New(logger *logging.Logger, config *Config) *Instaray {
 		threads:   config.Telegram.Threads,
 		logger:    logger,
 		embeds: []*embed.Embed{
-			embed.New("instagram", "ddinstagram.com"),
+			embed.New("instagram", "eeinstagram.com"),
 			embed.New("twitter", "fxtwitter.com"),
 			embed.New("x", "fixupx.com"),
 			embed.New("tiktok", "vxtiktok.com"),


### PR DESCRIPTION
The domain for the Instagram embed has been updated from ddinstagram.com to eeinstagram.com to ensure continued functionality and reliability.