### PR TITLE
fix(instaray): Update Instagram embed domain

### DIFF
--- a/internal/instaray/instaray.go
+++ b/internal/instaray/instaray.go
@@ -38,7 +38,7 @@ func New(logger *logging.Logger, config *Config) *Instaray {
 		threads:   config.Telegram.Threads,
 		logger:    logger,
 		embeds: []*embed.Embed{
-			embed.New("instagram", "eeinstagram.com"),
+			embed.New("instagram", "kkinstagram.com"),
 			embed.New("twitter", "fxtwitter.com"),
 			embed.New("x", "fixupx.com"),
 			embed.New("tiktok", "vxtiktok.com"),


### PR DESCRIPTION
The `instagram` embed provider URL has been updated from `eeinstagram.com` to
`kkinstagram.com`. This change ensures that Instagram content is correctly
processed and embedded within the application.

Signed-off-by: Enrique Hernández Bello <ehbello@gmail.com>
