### PR TITLE
fix(instaray): change instagram embed provider to vxinstagram

### DIFF
--- a/internal/instaray/instaray.go
+++ b/internal/instaray/instaray.go
@@ -38,7 +38,7 @@ func New(logger *logging.Logger, config *Config) *Instaray {
 		threads:   config.Telegram.Threads,
 		logger:    logger,
 		embeds: []*embed.Embed{
-			embed.New("instagram", "kkinstagram.com"),
+			embed.New("instagram", "vxinstagram.com"),
 			embed.New("twitter", "fxtwitter.com"),
 			embed.New("x", "fixupx.com"),
 			embed.New("tiktok", "vxtiktok.com"),


### PR DESCRIPTION
Update the Instagram embed URL from kkinstagram.com to vxinstagram.com
to ensure better compatibility and reliability for link previews.

Signed-off-by: Enrique Hernández Bello <ehbello@gmail.com>
