### PR TITLE
fix(embed): use mdbinstagram.com for Instagram embeds

### DIFF
--- a/internal/instaray/instaray.go
+++ b/internal/instaray/instaray.go
@@ -38,7 +38,7 @@ func New(logger *logging.Logger, config *Config) *Instaray {
 		threads:   config.Telegram.Threads,
 		logger:    logger,
 		embeds: []*embed.Embed{
-			embed.New("instagram", "vxinstagram.com"),
+			embed.New("instagram", "mdbinstagram.com"),
 			embed.New("twitter", "fxtwitter.com"),
 			embed.New("x", "fixupx.com"),
 			embed.New("tiktok", "vxtiktok.com"),


### PR DESCRIPTION
Replace the vxinstagram.com domain with mdbinstagram.com to resolve issues with Instagram link embedding.