### PR TITLE
fix(instaray): correct Instagram embed domain name

### DIFF
--- a/internal/instaray/instaray.go
+++ b/internal/instaray/instaray.go
@@ -38,7 +38,7 @@ func New(logger *logging.Logger, config *Config) *Instaray {
 		threads:   config.Telegram.Threads,
 		logger:    logger,
 		embeds: []*embed.Embed{
-			embed.New("instagram", "mdbinstagram.com"),
+			embed.New("instagram", "mbdinstagram.com"),
 			embed.New("twitter", "fxtwitter.com"),
 			embed.New("x", "fixupx.com"),
 			embed.New("tiktok", "vxtiktok.com"),


### PR DESCRIPTION
Fix typo in the Instagram embed domain, changing 'mdbinstagram.com'
to 'mbdinstagram.com'.

Signed-off-by: Enrique Hernández Bello <ehbello@gmail.com>
